### PR TITLE
Doc: add a header with a link to github #57

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,4 +1,5 @@
 # CASE Documentation 👋
+## [Github](https://github.com/casejs/CASE) <!-- {docsify-ignore} -->
 
 <span class="is-ib is-bordered">
 ![CASE App](../assets/images/cat-list.png ':class=is-bordered')


### PR DESCRIPTION
## Description
Added GitHub header in the introduction.md file

## Related Issues
#57 

## How can it be tested?
Run the docsify app locally. You will be able to locate the link in the introduction section.

## Checklist before submitting

- [✔️] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [✔️] I updated the documentation if necessary
- [✔️] This PR is wrote in clear language and correctly labeled
