### PR TITLE
feat: make relations available on BeforeInsert hook

### DIFF
--- a/docs/custom-logic.md
+++ b/docs/custom-logic.md
@@ -34,24 +34,40 @@ Events works with [TypeORM's entity listeners](https://typeorm.io/listeners-and-
 
 ### @BeforeInsert
 
-You can define a method with any name in entity and mark it with @BeforeInsert and CASE will call it before the entity is created.
+This hook will be called **before the entity is inserted to the DB**.
+
+It is useful for situations where you have to generate a field based on other values or from an external service. Here are some examples:
+
+- Call an API to get a value and store it
+- Generate a PDF a store its path
+- Generate a new field by mixing several fields
+- Stamp the current date
 
 ```js
 import { SHA3 } from 'crypto-js'
+import * as moment from "moment";
 
-[...]
 export class User {
- @Prop({
-   type: PropType.Password,
- })
- password: string
-
   @BeforeInsert()
   beforeInsert() {
+    // Hashes the password before storing it.
     this.password = SHA3(this.password).toString()
+
+    // Reference based on name and the first letters of a relation.
+    this.reference = `P-${this._relations.customer.name substring(0, 3)}-${this.name.substring(0, 3)}`
   }
 }
 ```
+
+#### Available data
+
+Some extra data is attached to the `this` object.
+
+| Option          | Type   | Description                                                   |
+| --------------- | ------ | ------------------------------------------------------------- |
+| **\_relations** | object | Contains the relation objects of the entity you are creating. |
+
+---
 
 ### @AfterInsert
 

--- a/packages/case/server/src/_contribution-root/entities/mouse.entity.ts
+++ b/packages/case/server/src/_contribution-root/entities/mouse.entity.ts
@@ -1,3 +1,5 @@
+import { BeforeInsert } from 'typeorm'
+
 import { PropType } from '../../../../shared/enums/prop-type.enum'
 import { CaseEntity } from '../../core-entities/case.entity'
 import { Entity } from '../../decorators/entity.decorator'
@@ -52,4 +54,9 @@ export class Mouse extends CaseEntity {
     type: PropType.Textarea
   })
   description: string
+
+  @BeforeInsert()
+  beforeInsert() {
+    this.description = `${this.nickName} is the mouse hunted by ${this._relations.predator.name}`
+  }
 }

--- a/packages/case/server/src/core-entities/case.entity.ts
+++ b/packages/case/server/src/core-entities/case.entity.ts
@@ -3,4 +3,6 @@ import { PrimaryGeneratedColumn } from 'typeorm'
 export class CaseEntity {
   @PrimaryGeneratedColumn()
   id: number
+
+  _relations?: { [key: string]: any }
 }

--- a/packages/case/server/src/dynamic-entity/dynamic-entity.seeder.ts
+++ b/packages/case/server/src/dynamic-entity/dynamic-entity.seeder.ts
@@ -106,7 +106,8 @@ export class DynamicEntitySeeder {
           }
         })
 
-        await entityRepository.save(newItem)
+        // Save without listeners to avoid triggering the beforeInsert hook.
+        await entityRepository.save(newItem, { listeners: false })
       }
     }
 


### PR DESCRIPTION
## Description

This was a missing critical feature. On entity file `@BeforeInsert()` hook, you may need to use the data of the relation of the entity you are creating

## Related Issues

None

## How can it be tested?

Start CASE as a contributor and create a `@BeforeInsert()` hook following the doc (local doc updated in this PR, not prod). If the entity has a relation, you can check to access it from here: 

```js
@BeforeInsert()
beforeInsert() {
console.log(this._relations)
}
```

## Check list before submitting

- [X] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [X] I updated the documentation if necessary
- [X] This PR is wrote in a clear language and correctly labeled
